### PR TITLE
Fix angr capitalization on FAQ page

### DIFF
--- a/templates/explorer/faq.html
+++ b/templates/explorer/faq.html
@@ -60,7 +60,7 @@
             <h5>What's in it?</h5>
             <p>The following decompilers are currently a part of the Decompiler Explorer:</p>
             <ul class="mx-3">
-                <li><a href="https://angr.io/">Angr</a></li>
+                <li><a href="https://angr.io/">angr</a></li>
                 <li><a href="https://binary.ninja">Binary Ninja</a></li>
                 <li><a href="https://github.com/BoomerangDecompiler/boomerang">Boomerang</a></li>
                 <li><a href="https://ghidra-sre.org">Ghidra</a></li>


### PR DESCRIPTION
Per [angr's docs](https://docs.angr.io/introductory-errata/faq#how-should-angr-be-stylized), angr is an anti-proper noun that should not be capitalized.