### PR TITLE
Use angr >= 9.2.1

### DIFF
--- a/runners/decompiler/Dockerfile
+++ b/runners/decompiler/Dockerfile
@@ -42,9 +42,9 @@ COPY runner_generic.py .
 ENTRYPOINT [ "./entrypoint.sh", "decompile_bn.py" ]
 
 
-# Angr
+# angr
 FROM base-x86 as angr
-RUN pip install --user 'angr>=9.1,<10.0'
+RUN pip install --user 'angr>=9.2.1,<10.0'
 COPY decompile_angr.py .
 
 COPY entrypoint.sh .

--- a/runners/decompiler/decompile_angr.py
+++ b/runners/decompiler/decompile_angr.py
@@ -34,7 +34,7 @@ def decompile():
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == '--version':
-        print('.'.join(str(i) for i in angr.__version__))
+        print(angr.__version__)
         print('')  # No revision information known
         sys.exit(0)
     if len(sys.argv) > 1 and sys.argv[1] == '--name':


### PR DESCRIPTION
For angr 9.2 I changed `angr.__version__` to be a string to be consistent with other popular libraries. This caused it to render with lots of extra `.`s.